### PR TITLE
Add patch 115 to support specifying service name

### DIFF
--- a/debian/patches/115_bonjour_servicename_support.patch
+++ b/debian/patches/115_bonjour_servicename_support.patch
@@ -1,0 +1,139 @@
+--- a/etc/netatalk/afp_avahi.c
++++ b/etc/netatalk/afp_avahi.c
+@@ -93,14 +93,26 @@ static void register_stuff(void) {
+ 
+         LOG(log_info, logtype_afpd, "hostname: %s", ctx->obj->options.hostname);
+ 
+-        if (convert_string(ctx->obj->options.unixcharset,
+-                           CH_UTF8,
+-                           ctx->obj->options.hostname,
+-                           -1,
+-                           name,
+-                           MAXINSTANCENAMELEN) <= 0) {
+-            LOG(log_error, logtype_afpd, "Could not set Zeroconf instance name: %s", ctx->obj->options.hostname);
+-            goto fail;
++        if (ctx->obj->options.servicename) {
++            if (convert_string(ctx->obj->options.unixcharset,
++                               CH_UTF8,
++                               ctx->obj->options.servicename,
++                               -1,
++                               name,
++                               MAXINSTANCENAMELEN) <= 0) {
++                LOG(log_error, logtype_afpd, "Could not set Zeroconf instance name: %s", ctx->obj->options.servicename);
++                goto fail;
++            }
++        } else {
++            if (convert_string(ctx->obj->options.unixcharset,
++                               CH_UTF8,
++                               ctx->obj->options.hostname,
++                               -1,
++                               name,
++                               MAXINSTANCENAMELEN) <= 0) {
++                LOG(log_error, logtype_afpd, "Could not set Zeroconf instance name: %s", ctx->obj->options.hostname);
++                goto fail;
++            }
+         }
+ 
+         LOG(log_info, logtype_afpd, "Registering server '%s' with Bonjour", name);            
+--- a/etc/netatalk/afp_mdns.c
++++ b/etc/netatalk/afp_mdns.c
+@@ -36,7 +36,7 @@ static pthread_t       poller;
+  * Its easier to use asprintf to set the TXT record values
+  */
+ 
+-int TXTRecordPrintf(TXTRecordRef * rec, const char * key, const char * fmt, ... ) 
++int TXTRecordPrintf(TXTRecordRef * rec, const char * key, const char * fmt, ... )
+ {
+     int ret = 0;
+     char *str;
+@@ -45,7 +45,7 @@ int TXTRecordPrintf(TXTRecordRef * rec,
+ 
+     if( 0 > vasprintf(&str, fmt, ap ) ) {
+         va_end(ap);
+-        return -1;    
++        return -1;
+     }
+     va_end(ap);
+ 
+@@ -57,7 +57,7 @@ int TXTRecordPrintf(TXTRecordRef * rec,
+     return ret;
+ }
+ 
+-int TXTRecordKeyPrintf(TXTRecordRef * rec, const char * key_fmt, int key_var, const char * fmt, ...) 
++int TXTRecordKeyPrintf(TXTRecordRef * rec, const char * key_fmt, int key_var, const char * fmt, ...)
+ {
+     int ret = 0;
+     char *key = NULL, *str = NULL;
+@@ -135,7 +135,7 @@ static void RegisterReply(DNSServiceRef
+  * registered and frees associated memory
+  */
+ static void unregister_stuff() {
+-    pthread_cancel(poller);    
++    pthread_cancel(poller);
+ 
+     for (int i = 0; i < svc_ref_count; i++)
+         close(fds[i].fd);
+@@ -212,14 +212,26 @@ static void register_stuff(const AFPObj
+ 
+     port = atoi(obj->options.port);
+ 
+-    if (convert_string(obj->options.unixcharset,
+-                       CH_UTF8,
+-                       obj->options.hostname,
+-                       -1,
+-                       name,
+-                       MAXINSTANCENAMELEN) <= 0) {
+-        LOG(log_error, logtype_afpd, "Could not set Zeroconf instance name");
+-        goto fail;
++    if (obj->options.servicename) {
++        if (convert_string(obj->options.unixcharset,
++                            CH_UTF8,
++                            obj->options.servicename,
++                            -1,
++                            name,
++                            MAXINSTANCENAMELEN) <= 0) {
++            LOG(log_error, logtype_afpd, "Could not set Zeroconf instance name: %s", obj->options.servicename);
++            goto fail;
++        }
++    } else {
++        if (convert_string(obj->options.unixcharset,
++                           CH_UTF8,
++                           obj->options.hostname,
++                           -1,
++                           name,
++                           MAXINSTANCENAMELEN) <= 0) {
++            LOG(log_error, logtype_afpd, "Could not set Zeroconf instance name: %s", obj->options.hostname);
++            goto fail;
++        }
+     }
+ 
+     error = DNSServiceRegister(&svc_refs[svc_ref_count++],
+--- a/include/atalk/globals.h
++++ b/include/atalk/globals.h
+@@ -127,6 +127,7 @@ struct afp_options {
+     char *logconfig;
+     char *logfile;
+     char *mimicmodel;
++    char *servicename;
+     char *adminauthuser;
+     char *ignored_attr;
+     int  splice_size;
+--- a/libatalk/util/netatalk_conf.c
++++ b/libatalk/util/netatalk_conf.c
+@@ -1963,6 +1963,7 @@ int afp_config_parse(AFPObj *AFPObj, cha
+     options->addomain       = atalk_iniparser_getstrdup(config, INISEC_GLOBAL, "ad domain",      NULL);
+     options->ntseparator    = atalk_iniparser_getstrdup(config, INISEC_GLOBAL, "nt separator",   NULL);
+     options->mimicmodel     = atalk_iniparser_getstrdup(config, INISEC_GLOBAL, "mimic model",    NULL);
++    options->servicename    = atalk_iniparser_getstrdup(config, INISEC_GLOBAL, "service name",    NULL);
+     options->adminauthuser  = atalk_iniparser_getstrdup(config, INISEC_GLOBAL, "admin auth user",NULL);
+     options->ignored_attr   = atalk_iniparser_getstrdup(config, INISEC_GLOBAL, "ignored attributes", NULL);
+     options->cnid_mysql_host = atalk_iniparser_getstrdup(config, INISEC_GLOBAL, "cnid mysql host", NULL);
+@@ -2193,6 +2194,8 @@ void afp_config_free(AFPObj *obj)
+         CONFIG_ARG_FREE(obj->options.ntseparator);
+     if (obj->options.mimicmodel)
+         CONFIG_ARG_FREE(obj->options.mimicmodel);
++    if (obj->options.servicename)
++        CONFIG_ARG_FREE(obj->options.servicename);
+     if (obj->options.adminauthuser)
+         CONFIG_ARG_FREE(obj->options.adminauthuser);
+     if (obj->options.hostname)

--- a/debian/patches/series
+++ b/debian/patches/series
@@ -1,2 +1,3 @@
 114_fix_macusers_ps_parsing.patch
+115_bonjour_servicename_support.patch
 402_init_lsb.patch


### PR DESCRIPTION
Hello Adrian.

Let's try to keep the service name in Debian for now. Please let me know if anything is wrong.

--
Stan