### PR TITLE
licensecheck is part of the devscripts package

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -5,7 +5,7 @@ Maintainer: Debian Netatalk Packaging <pkg-netatalk-devel@lists.alioth.debian.or
 Uploaders: Jonas Smedegaard <dr@jones.dk>
 Build-Depends: cdbs (>= 0.4.106~),
  autotools-dev,
- licensecheck,
+ licensecheck | devscripts (<< 2.16.6),
  debhelper,
  dh-buildinfo,
  libdb-dev,


### PR DESCRIPTION
This change should avoid a licensecheck unmet dependency error.