### PR TITLE
Build .debs on Travis CI and upload releases

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,12 @@
+sudo: required
+language: generic
+
+services:
+  - docker
+
+script:
+  - wget -O- http://travis.debian.net/script.sh | sh -
+
+branches:
+  except:
+    - /^debian\/\d/

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,17 @@
 sudo: required
 language: generic
-
 services:
-  - docker
-
+- docker
 script:
-  - wget -O- http://travis.debian.net/script.sh | sh -
-
+- wget -O- http://travis.debian.net/script.sh | sh -
 branches:
   except:
-    - /^debian\/\d/
+  - /^debian\/\d/
+deploy:
+  provider: releases
+  api_key:
+    secure: lYzplaxPCd5mZYQkG5lG9gwg05b1kWLQAdx2lPAdW5FH+FwUpc2pMsAkNuBJIt57b+2Sz7c44FpLZgW4BVFT0Mmb/Ng3b5kOnaK3HKqp8nWRGDunxFz8u9d3DcGU8kdMqgc2DneC/+LSQ23a+B8Pg0xqZAGnyX8MeEh0W00dRHIw0g72/56bLzRJMIovo2kDbTSax70k5IHzmFOr454AgBrBwjAjhWXtgisyd1qUmxMvW3Grvsw/zWHbuth4u+i20CpT1DQCnMMjj6EdShREN0c5hJFbz9J5+dWKRuR0xZinYk1CLfaCEIWPGMZiS4uAqd6c2oUtP7by9R8vri1qKU29GOK1g3QgmjTrWtGzkpurcmVDTHPqRvbrfQ7ZTKn/zeJ4cRzcVEs9q65msIj/NOPyTxYc/FSxEsWEEFfMCpVgza9s+W/I7LkD/ZRxMUBX8xf4WgEFsaZxFFlzXippP6uyHLi/FE8wM3q4yHoD+pQpIPjG/lhZdSDVUkCoLhoNKQlrnJWBh02zS7Apb6dNEC5jZhFMwmnDBt3gy2YXNsKOQ/ZCox5PbkrCBsHInE8qD80sRGSGTCu09K5YUy5dvGsjccypKyD89tsoBcpYG1rWyAcQOcR+CSXMJ/WL/uMFZB69+2B2Lm1etKUOGPHxW2uSIl+NfwORQkUQBi1Pu34=
+  file_glob: true
+  file: ../*.deb
+  on:
+    repo: dgilman/netatalk-debian

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,9 @@
 sudo: required
 language: generic
+env:
+- TRAVIS_DEBIAN_DISTRIBUTION=jessie
+- TRAVIS_DEBIAN_DISTRIBUTION=stretch
+- TRAVIS_DEBIAN_DISTRIBUTION=buster
 services:
 - docker
 script:
@@ -7,6 +11,8 @@ script:
 branches:
   except:
   - /^debian\/\d/
+after_success:
+- /bin/bash -c 'cd ..; for deb in *.deb; do mv "$deb" "$TRAVIS_DEBIAN_DISTRIBUTION"_"$deb"; done'
 deploy:
   provider: releases
   api_key:
@@ -14,4 +20,4 @@ deploy:
   file_glob: true
   file: ../*.deb
   on:
-    repo: dgilman/netatalk-debian
+    tags: true

--- a/debian/source/options
+++ b/debian/source/options
@@ -1,0 +1,1 @@
+extend-diff-ignore = "^\.travis\.yml$"


### PR DESCRIPTION
I've created a Travis CI configuration that will build .debs under oldstable, stable and testing.

It also has configuration to upload the .debs to GitHub when a new git tag is cut.  They'll show up on the Releases page after a successful build.  Personally, I find this very convenient and I'm OK with running Travis Ci built binaries on my home servers.  I imagine that a lot of casual users will also find it convenient to use the prebuilt binaries and you, the maintainer, will find the automated uploading of these binaries to be a timesaver.  However, if you do not think it is appropriate to distribute or use binaries built in Travis I respect that opinion.  You can strip out the deployment step easily.

In order to get the releases uploading to your repository you'll need to change the api_key field to one for your github account.  I forgot how I did this when I did it six months ago, but i think I just ran "travis setup releases" and copied it from that output.  It also might be worth it to put in a README.md in the root to let people know that .debs are available.